### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/app/Scrapper.py
+++ b/app/Scrapper.py
@@ -49,9 +49,15 @@ class Scrape:
         pass
 
     def get_local_file_path_by_path(self, path):
-        self.local_file_path = os.path.join(static_path, path)
+        normalized_path = os.path.normpath(os.path.join(static_path, path))
+        if not normalized_path.startswith(static_path):
+            raise Exception("Invalid path")
+        self.local_file_path = normalized_path
         return self.local_file_path
 
     def get_local_file_path_by_asin_id(self, asin_id):
-        self.local_file_path = os.path.join(static_path, "product_page/" + asin_id)
+        normalized_path = os.path.normpath(os.path.join(static_path, "product_page/" + asin_id))
+        if not normalized_path.startswith(static_path):
+            raise Exception("Invalid path")
+        self.local_file_path = normalized_path
         return self.local_file_path


### PR DESCRIPTION
Fixes [https://github.com/susantp/scrapper_api/security/code-scanning/3](https://github.com/susantp/scrapper_api/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This can be achieved by normalizing the path and checking that it starts with the root directory. We will use `os.path.normpath` to normalize the path and then verify that the normalized path starts with the `static_path`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
